### PR TITLE
Add support to JDK 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java_version: [ 8, 11 ]
+        java_version: [ 8, 11, 17 ]
 
     steps:
     - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
         <!-- Test dependencies versions -->
         <junit4.version>4.13.2</junit4.version>
-        <powermock.version>2.0.9</powermock.version>
+        <mockito.version>4.9.0</mockito.version>
         <junit-utils.version>1.3.1</junit-utils.version>
     </properties>
 
@@ -142,19 +142,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-inline -->
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.9.0</version>
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>net.obvj</groupId>

--- a/src/test/java/net/obvj/jep/functions/HttpGetTest.java
+++ b/src/test/java/net/obvj/jep/functions/HttpGetTest.java
@@ -6,14 +6,12 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Stack;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.nfunk.jep.ParseException;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import net.obvj.jep.http.WebServiceUtils;
 import net.obvj.jep.util.CollectionsUtils;
@@ -23,8 +21,7 @@ import net.obvj.jep.util.CollectionsUtils;
  *
  * @author oswaldo.bapvic.jr
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(WebServiceUtils.class)
+@RunWith(MockitoJUnitRunner.class)
 public class HttpGetTest
 {
     private static final String URL = "http://sampleservice.com/data/v1/wheather/sp";
@@ -35,15 +32,6 @@ public class HttpGetTest
 
     // Test subject
     private static HttpGet function = new HttpGet();
-
-    /**
-     * Setup test objects before each test
-     */
-    @Before
-    public void setup()
-    {
-        PowerMockito.mockStatic(WebServiceUtils.class);
-    }
 
     /**
      * Runs the function with the given parameters
@@ -61,17 +49,15 @@ public class HttpGetTest
     @Test
     public void testSuccessfulScenarioWithUrlParam() throws org.nfunk.jep.ParseException, IOException
     {
-        PowerMockito.when(WebServiceUtils.getAsString(URL)).thenReturn(CONTENT_JSON);
-
         Stack<Object> parameters = CollectionsUtils.newParametersStack(URL);
-        run(parameters);
+        try (MockedStatic<WebServiceUtils> mock = Mockito.mockStatic(WebServiceUtils.class))
+        {
+            mock.when(() -> WebServiceUtils.getAsString(URL)).thenReturn(CONTENT_JSON);
 
-        // Check that the content from mock is returned
-        assertEquals(CONTENT_JSON, parameters.pop());
-
-        // Check that the correct method from the mock was called once
-        PowerMockito.verifyStatic(WebServiceUtils.class, BDDMockito.times(1));
-        WebServiceUtils.getAsString(URL);
+            run(parameters);
+            // Check that the content from mock is returned
+            assertEquals(CONTENT_JSON, parameters.pop());
+        }
     }
 
     /**
@@ -81,17 +67,15 @@ public class HttpGetTest
     @Test
     public void testSuccessfulScenarioWithUrlAndHeaderParams() throws org.nfunk.jep.ParseException, IOException
     {
-        PowerMockito.when(WebServiceUtils.getAsString(URL, HEADERS)).thenReturn(CONTENT_XML);
-
         Stack<Object> parameters = CollectionsUtils.newParametersStack(URL, HEADERS);
-        run(parameters);
+        try (MockedStatic<WebServiceUtils> mock = Mockito.mockStatic(WebServiceUtils.class))
+        {
+            mock.when(() -> WebServiceUtils.getAsString(URL, HEADERS)).thenReturn(CONTENT_XML);
 
-        // Check that the content from mocked is returned
-        assertEquals(CONTENT_XML, parameters.pop());
-
-        // Check that the correct method from the mock was called once
-        PowerMockito.verifyStatic(WebServiceUtils.class, BDDMockito.times(1));
-        WebServiceUtils.getAsString(URL, HEADERS);
+            run(parameters);
+            // Check that the content from mock is returned
+            assertEquals(CONTENT_XML, parameters.pop());
+        }
     }
 
     /**

--- a/src/test/java/net/obvj/jep/functions/HttpResponseHandlerTest.java
+++ b/src/test/java/net/obvj/jep/functions/HttpResponseHandlerTest.java
@@ -10,9 +10,9 @@ import javax.ws.rs.core.Response.Status;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.nfunk.jep.ParseException;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import net.obvj.jep.functions.HttpResponseHandler.Strategy;
 import net.obvj.jep.http.WebServiceResponse;
@@ -23,7 +23,7 @@ import net.obvj.jep.util.CollectionsUtils;
  *
  * @author oswaldo.bapvic.jr
  */
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class HttpResponseHandlerTest
 {
     private static final int STATUS_CODE_OK = 200;
@@ -33,7 +33,8 @@ public class HttpResponseHandlerTest
     private static HttpResponseHandler httpStatusCodeFunction = new HttpResponseHandler(Strategy.GET_STATUS_CODE);
     private static HttpResponseHandler httpResponseFunction = new HttpResponseHandler(Strategy.GET_RESPONSE);
 
-    private Response clientResponse = PowerMockito.mock(Response.class);
+    @Mock
+    private Response clientResponse;
 
     /**
      * Utility method to mock the Client response with a given HTTP status and body

--- a/src/test/java/net/obvj/jep/functions/HttpTest.java
+++ b/src/test/java/net/obvj/jep/functions/HttpTest.java
@@ -2,20 +2,18 @@ package net.obvj.jep.functions;
 
 import static net.obvj.jep.util.CollectionsUtils.newParametersStack;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.times;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.Stack;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.nfunk.jep.ParseException;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import net.obvj.jep.http.WebServiceResponse;
 import net.obvj.jep.http.WebServiceUtils;
@@ -26,8 +24,7 @@ import net.obvj.jep.util.CollectionsUtils;
  *
  * @author oswaldo.bapvic.jr
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(WebServiceUtils.class)
+@RunWith(MockitoJUnitRunner.class)
 public class HttpTest
 {
     private static final String EMPLOYEE_URL = "http://dummy.restapiexample.com/api/v1/employee";
@@ -41,12 +38,6 @@ public class HttpTest
 
     @Mock
     private WebServiceResponse response;
-
-    @Before
-    public void setup()
-    {
-        PowerMockito.mockStatic(WebServiceUtils.class);
-    }
 
     /**
      * Runs the function with the given parameters
@@ -64,12 +55,16 @@ public class HttpTest
     @Test
     public void testPostWithRequestBody() throws org.nfunk.jep.ParseException, IOException
     {
-        PowerMockito.when(WebServiceUtils.invoke(POST, EMPLOYEE_URL, EMPLOYEE_REQUEST_BODY, null)).thenReturn(response);
-
         Stack<Object> parameters = newParametersStack(POST, EMPLOYEE_URL, EMPLOYEE_REQUEST_BODY);
-        run(parameters);
 
-        assertEquals(response, parameters.pop());
+        try (MockedStatic<WebServiceUtils> mock = Mockito.mockStatic(WebServiceUtils.class))
+        {
+            mock.when(() -> WebServiceUtils.invoke(POST, EMPLOYEE_URL, EMPLOYEE_REQUEST_BODY, null))
+                    .thenReturn(response);
+
+            run(parameters);
+            assertEquals(response, parameters.pop());
+        }
     }
 
     /**
@@ -88,13 +83,16 @@ public class HttpTest
     @Test
     public void testWithThreeParameters() throws org.nfunk.jep.ParseException, IOException
     {
-        // Test
         Stack<Object> parameters = newParametersStack(POST, EMPLOYEE_URL, EMPLOYEE_REQUEST_BODY);
-        run(parameters);
 
-        // Verify the correct method was called
-        PowerMockito.verifyStatic(WebServiceUtils.class, times(1));
-        WebServiceUtils.invoke(POST, EMPLOYEE_URL, EMPLOYEE_REQUEST_BODY, null);
+        try (MockedStatic<WebServiceUtils> mock = Mockito.mockStatic(WebServiceUtils.class))
+        {
+            mock.when(() -> WebServiceUtils.invoke(POST, EMPLOYEE_URL, EMPLOYEE_REQUEST_BODY, null))
+                    .thenReturn(response);
+
+            run(parameters);
+            assertEquals(response, parameters.pop());
+        }
     }
 
     /**
@@ -103,13 +101,16 @@ public class HttpTest
     @Test
     public void testWithFourParameters() throws org.nfunk.jep.ParseException, IOException
     {
-        // Test
         Stack<Object> parameters = newParametersStack(POST, EMPLOYEE_URL, EMPLOYEE_REQUEST_BODY, HEADERS);
-        run(parameters);
 
-        // Verify the correct method was called
-        PowerMockito.verifyStatic(WebServiceUtils.class, times(1));
-        WebServiceUtils.invoke(POST, EMPLOYEE_URL, EMPLOYEE_REQUEST_BODY, HEADERS);
+        try (MockedStatic<WebServiceUtils> mock = Mockito.mockStatic(WebServiceUtils.class))
+        {
+            mock.when(() -> WebServiceUtils.invoke(POST, EMPLOYEE_URL, EMPLOYEE_REQUEST_BODY, HEADERS))
+                    .thenReturn(response);
+
+            run(parameters);
+            assertEquals(response, parameters.pop());
+        }
     }
 
     /**

--- a/src/test/java/net/obvj/jep/functions/ReadFileTest.java
+++ b/src/test/java/net/obvj/jep/functions/ReadFileTest.java
@@ -5,14 +5,12 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.util.Stack;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.nfunk.jep.ParseException;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import net.obvj.jep.util.CollectionsUtils;
 import net.obvj.jep.util.FileUtils;
@@ -22,8 +20,7 @@ import net.obvj.jep.util.FileUtils;
  *
  * @author oswaldo.bapvic.jr
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(FileUtils.class)
+@RunWith(MockitoJUnitRunner.class)
 public class ReadFileTest
 {
     private static final String PATH = "/tmp/data.json";
@@ -33,31 +30,22 @@ public class ReadFileTest
     private static ReadFile function = new ReadFile();
 
     /**
-     * Setup test objects before each test
-     */
-    @Before
-    public void setup()
-    {
-        PowerMockito.mockStatic(FileUtils.class);
-    }
-
-    /**
      * Checks that the correct method from TextFileUtils was called. Successful scenario
      */
     @Test
     public void testSuccessfulScenario() throws org.nfunk.jep.ParseException, IOException
     {
-        PowerMockito.when(FileUtils.readFromFileSystem(PATH)).thenReturn(CONTENT);
+        try (MockedStatic<FileUtils> fileUtils = Mockito.mockStatic(FileUtils.class))
+        {
+            fileUtils.when(() -> FileUtils.readFromFileSystem(PATH)).thenReturn(CONTENT);
 
-        Stack<Object> parameters = CollectionsUtils.newParametersStack(PATH);
-        function.run(parameters);
+            Stack<Object> parameters = CollectionsUtils.newParametersStack(PATH);
+            function.run(parameters);
 
-        // Check that the content from mocked TextFileReader is returned
-        assertEquals(CONTENT, parameters.pop());
+            // Check that the content from mocked TextFileReader is returned
+            assertEquals(CONTENT, parameters.pop());
+        }
 
-        // Check that the correct method from the mock was called once
-        PowerMockito.verifyStatic(FileUtils.class, BDDMockito.times(1));
-        FileUtils.readFromFileSystem(PATH);
     }
 
     /**
@@ -66,10 +54,14 @@ public class ReadFileTest
     @Test(expected = ParseException.class)
     public void testExceptionalScenario() throws org.nfunk.jep.ParseException, IOException
     {
-        PowerMockito.when(FileUtils.readFromFileSystem(PATH)).thenThrow(new IOException("Mocked exception"));
+        try (MockedStatic<FileUtils> fileUtils = Mockito.mockStatic(FileUtils.class))
+        {
+            fileUtils.when(() -> FileUtils.readFromFileSystem(PATH))
+                    .thenThrow(new IOException("Mocked exception"));
 
-        Stack<Object> parameters = CollectionsUtils.newParametersStack(PATH);
-        function.run(parameters);
+            Stack<Object> parameters = CollectionsUtils.newParametersStack(PATH);
+            function.run(parameters);
+        }
     }
 
 }

--- a/src/test/java/net/obvj/jep/http/WebServiceResponseTest.java
+++ b/src/test/java/net/obvj/jep/http/WebServiceResponseTest.java
@@ -11,14 +11,14 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Unit tests for the {@link WebServiceResponse} class.
  *
  * @author oswaldo.bapvic.jr
  */
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class WebServiceResponseTest
 {
     @Mock


### PR DESCRIPTION
PowerMock usage is blocking migration to JDK 17.
Replace PowerMock with Mockito Inline.